### PR TITLE
Make code examples inside tables 100% wide

### DIFF
--- a/source/stylesheets/_govuk_styling.scss
+++ b/source/stylesheets/_govuk_styling.scss
@@ -312,7 +312,10 @@ aside {
 	font-size: 16px;
 }
 
-
+.page-wrapper .dark-box, .content table pre,
+.page-wrapper .dark-box, .content table code {
+	width: 100%;
+}
 
 code{
     white-space: nowrap;


### PR DESCRIPTION
# Before

![image](https://cloud.githubusercontent.com/assets/355079/18352177/3fe1fa6a-75d5-11e6-86c9-63223261fb98.png)


# After

![image](https://cloud.githubusercontent.com/assets/355079/18352165/335102aa-75d5-11e6-8a70-0918bdb67654.png)
